### PR TITLE
Update rack gem to a secure version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       rack (>= 1.2, < 3)
     power_assert (1.1.3)
     psych (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rake (12.3.1)
     rdoc (6.0.4)
     redis (3.0.6)


### PR DESCRIPTION
SW-277

Responding to [this security alert](https://github.com/paperlesspost/redised/network/alert/Gemfile.lock/rack/open).