### PR TITLE
Bump Gem versions to allow using with Rails 5's redis cache store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"
-gem 'redis', '~>3'
+gem 'redis', '~> 4.0'
 gem 'redis-namespace'
 
 # Add dependencies to develop your gem here.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,9 +48,9 @@ GEM
     rack (2.0.6)
     rake (12.3.1)
     rdoc (6.0.4)
-    redis (3.0.6)
-    redis-namespace (1.3.2)
-      redis (~> 3.0.4)
+    redis (4.2.5)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     semver2 (3.4.2)
     shoulda (2.11.3)
     test-unit (3.2.8)
@@ -64,10 +64,10 @@ DEPENDENCIES
   bundler (~> 1.0)
   jeweler
   minitest
-  redis (~> 3)
+  redis (~> 4.0)
   redis-namespace
   shoulda
   test-unit
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
We need to bump the `redis` gem dependency in order to be able to use Rails 5's redis cache store:
https://github.com/rails/rails/blob/v5.2.4.4/activesupport/lib/active_support/cache/redis_cache_store.rb#L4
